### PR TITLE
Update/follow up (formerly clinical assessment)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,17 @@
 Changes
 =======
 
-initial
--------
+[unreleased]
+------------
+- changes to Follow-up (formerly Clinical Assessment):
+    - rename/standardise 'Clinical Assessment' to be 'Follow-up' throughout
+    - add survival status help text, for 'Deceased' and 'Alive, but unwell' choices
+    - modify adherence_counselling to only be applicable if not 'Deceased'
+
+0.1.1
+-----
+- add migrations
+
+0.1.0
+-----
+- initial release

--- a/effect_subject/admin/followup_admin.py
+++ b/effect_subject/admin/followup_admin.py
@@ -15,7 +15,7 @@ class FollowupAdmin(CrfModelAdmin):
     fieldsets = (
         (None, {"fields": ("subject_visit", "report_datetime")}),
         (
-            "Followup",
+            "Follow-up",
             {
                 "fields": (
                     "assessment_type",

--- a/effect_subject/choices.py
+++ b/effect_subject/choices.py
@@ -17,6 +17,7 @@ from edc_reportable.constants import GRADE3, GRADE4
 from edc_visit_tracking.constants import MISSED_VISIT, SCHEDULED, UNSCHEDULED
 
 from .constants import (
+    ALIVE_UNWELL,
     APPT,
     APPT_OTHER,
     DECREASED,
@@ -187,7 +188,7 @@ PRESENT_ABSENT_NOEXAM_NDS = (
 
 PATIENT_STATUSES = (
     ("alive_well", "Alive and well"),
-    ("alive_unwell", "Alive, but unwell"),
+    (ALIVE_UNWELL, "Alive, but unwell"),
     (DEAD, "Deceased"),
 )
 

--- a/effect_subject/constants.py
+++ b/effect_subject/constants.py
@@ -1,3 +1,4 @@
+ALIVE_UNWELL = "alive_unwell"
 APPT = "appt"
 APPT_OTHER = "other_routine_appt"
 DECREASED = "decreased"

--- a/effect_subject/forms/followup_form.py
+++ b/effect_subject/forms/followup_form.py
@@ -17,7 +17,14 @@ class FollowupFormValidator(GlucoseFormValidatorMixin, FormValidator):
         )
         self.validate_other_specify(field="info_source")
         self.validate_survival_status()
-        self.validate_adherence_counselling()
+        self.not_applicable_if(
+            DEAD,
+            field="survival_status",
+            field_applicable="adherence_counselling",
+            not_applicable_msg=(
+                "Invalid: Expected 'Not applicable' if survival status is 'Deceased'"
+            ),
+        )
 
     def validate_survival_status(self):
         if (
@@ -42,20 +49,6 @@ class FollowupFormValidator(GlucoseFormValidatorMixin, FormValidator):
                     "survival_status": (
                         "Invalid: Unexpected survival status 'Deceased' if "
                         "'Telephone' visit with 'Patient'"
-                    )
-                }
-            )
-
-    def validate_adherence_counselling(self):
-        if (
-            self.cleaned_data.get("adherence_counselling") == YES
-            and self.cleaned_data.get("survival_status") == DEAD
-        ):
-            raise forms.ValidationError(
-                {
-                    "adherence_counselling": (
-                        "Invalid: Adherence counselling not expected if "
-                        "survival status is 'Deceased'"
                     )
                 }
             )

--- a/effect_subject/models/followup.py
+++ b/effect_subject/models/followup.py
@@ -1,9 +1,10 @@
 from django.db import models
-from edc_constants.choices import YES_NO
+from edc_constants.choices import YES_NO, YES_NO_NA
+from edc_constants.constants import DEAD
 from edc_model import models as edc_models
 
 from ..choices import ASSESSMENT_TYPES, INFO_SOURCES, PATIENT_STATUSES
-from ..constants import PATIENT
+from ..constants import ALIVE_UNWELL, PATIENT
 from ..model_mixins import CrfModelMixin
 
 
@@ -32,6 +33,11 @@ class Followup(CrfModelMixin, edc_models.BaseUuidModel):
         # TODO: Validate against visit survival status
         # TODO: If dead, trigger SAE -> death form -> off study
         choices=PATIENT_STATUSES,
+        help_text=(
+            f"If subject '{dict(PATIENT_STATUSES)[ALIVE_UNWELL]}, "
+            "consider unscheduled visit, or AE report. "
+            f"If subject '{dict(PATIENT_STATUSES)[DEAD]}', submit death report"
+        ),
     )
 
     hospitalized = models.CharField(
@@ -44,9 +50,9 @@ class Followup(CrfModelMixin, edc_models.BaseUuidModel):
     adherence_counselling = models.CharField(
         verbose_name="Was adherence counselling given?",
         max_length=15,
-        choices=YES_NO,
+        choices=YES_NO_NA,
     )
 
     class Meta(CrfModelMixin.Meta, edc_models.BaseUuidModel.Meta):
-        verbose_name = "Clinical Assessment"
-        verbose_name_plural = "Clinical Assessment"
+        verbose_name = "Follow-up"
+        verbose_name_plural = "Follow-up"

--- a/effect_subject/tests/tests/test_followup.py
+++ b/effect_subject/tests/tests/test_followup.py
@@ -77,70 +77,64 @@ class TestFollowupFormValidation(EffectTestCaseMixin, TestCase):
         cleaned_data = self.get_valid_in_person_visit_data()
         cleaned_data.update({"info_source": PATIENT})
         form_validator = self.validate_form_validator(cleaned_data)
-        self.assertIn("info_source", form_validator._errors)
-        self.assertIn(
-            "This field is not applicable.",
-            str(form_validator._errors.get("info_source")),
+        self.assertFieldFormValidationErrorRaised(
+            form_validator=form_validator,
+            field="info_source",
+            expected_msg="This field is not applicable.",
         )
-        self.assertEqual(len(form_validator._errors), 1, form_validator._errors)
 
     def test_info_source_applicable_for_telephone_assessments(self):
         cleaned_data = self.get_valid_patient_telephone_assessment_data()
         cleaned_data.update({"info_source": NOT_APPLICABLE})
         form_validator = self.validate_form_validator(cleaned_data)
-        self.assertIn("info_source", form_validator._errors)
-        self.assertIn(
-            "This field is applicable.",
-            str(form_validator._errors.get("info_source")),
+        self.assertFieldFormValidationErrorRaised(
+            form_validator=form_validator,
+            field="info_source",
+            expected_msg="This field is applicable.",
         )
-        self.assertEqual(len(form_validator._errors), 1, form_validator._errors)
 
     def test_info_source_other_required_if_specified(self):
         cleaned_data = self.get_valid_patient_telephone_assessment_data()
         cleaned_data.update({"info_source": OTHER})
         form_validator = self.validate_form_validator(cleaned_data)
-        self.assertIn("info_source_other", form_validator._errors)
-        self.assertIn(
-            "This field is required.",
-            str(form_validator._errors.get("info_source_other")),
+        self.assertFieldFormValidationErrorRaised(
+            form_validator=form_validator,
+            field="info_source_other",
+            expected_msg="This field is required.",
         )
-        self.assertEqual(len(form_validator._errors), 1, form_validator._errors)
 
     def test_info_source_other_not_required_if_not_specified(self):
         cleaned_data = self.get_valid_patient_telephone_assessment_data()
         cleaned_data.update({"info_source_other": "xxx"})
         form_validator = self.validate_form_validator(cleaned_data)
-        self.assertIn("info_source_other", form_validator._errors)
-        self.assertIn(
-            "This field is not required.",
-            str(form_validator._errors.get("info_source_other")),
+        self.assertFieldFormValidationErrorRaised(
+            form_validator=form_validator,
+            field="info_source_other",
+            expected_msg="This field is not required.",
         )
-        self.assertEqual(len(form_validator._errors), 1, form_validator._errors)
 
     def test_deceased_status_invalid_for_in_person_visit(self):
         cleaned_data = self.get_valid_in_person_visit_data()
         cleaned_data.update({"survival_status": DEAD})
         form_validator = self.validate_form_validator(cleaned_data)
-        self.assertIn("survival_status", form_validator._errors)
-        self.assertIn(
-            "Invalid: Unexpected survival status 'Deceased' if 'In person' visit",
-            str(form_validator._errors.get("survival_status")),
+        self.assertFieldFormValidationErrorRaised(
+            form_validator=form_validator,
+            field="survival_status",
+            expected_msg="Invalid: Unexpected survival status 'Deceased' if 'In person' visit",
         )
-        self.assertEqual(len(form_validator._errors), 1, form_validator._errors)
 
     def test_deceased_status_invalid_for_patient_telephone_visit(self):
         cleaned_data = self.get_valid_patient_telephone_assessment_data()
         cleaned_data.update({"survival_status": DEAD})
         form_validator = self.validate_form_validator(cleaned_data)
-        self.assertIn("survival_status", form_validator._errors)
-        self.assertIn(
-            (
+        self.assertFieldFormValidationErrorRaised(
+            form_validator=form_validator,
+            field="survival_status",
+            expected_msg=(
                 "Invalid: Unexpected survival status 'Deceased' if "
                 "'Telephone' visit with 'Patient'"
             ),
-            str(form_validator._errors.get("survival_status")),
         )
-        self.assertEqual(len(form_validator._errors), 1, form_validator._errors)
 
     def test_deceased_status_valid_for_other_telephone_visits(self):
         info_sources = [

--- a/effect_subject/tests/tests/test_followup.py
+++ b/effect_subject/tests/tests/test_followup.py
@@ -1,16 +1,17 @@
 from copy import deepcopy
 
-from django.test import TestCase
+from django.test import TestCase, tag
 from edc_constants.constants import DEAD, NO, NOT_APPLICABLE, OTHER, YES
 from model_bakery import baker
 
 from effect_screening.tests.effect_test_case_mixin import EffectTestCaseMixin
-from effect_subject.choices import INFO_SOURCES
+from effect_subject.choices import INFO_SOURCES, PATIENT_STATUSES
 from effect_subject.constants import IN_PERSON, PATIENT, TELEPHONE
 from effect_subject.forms import FollowupForm
 from effect_subject.forms.followup_form import FollowupFormValidator
 
 
+@tag("fu")
 class TestFollowup(EffectTestCaseMixin, TestCase):
     def setUp(self):
         super().setUp()
@@ -23,6 +24,7 @@ class TestFollowup(EffectTestCaseMixin, TestCase):
         form.is_valid()
 
 
+@tag("fu")
 class TestFollowupFormValidation(EffectTestCaseMixin, TestCase):
 
     form_validator_default_form_cls = FollowupFormValidator
@@ -154,22 +156,39 @@ class TestFollowupFormValidation(EffectTestCaseMixin, TestCase):
                         "info_source": info_src,
                         "info_source_other": "xxx" if info_src == OTHER else "",
                         "survival_status": DEAD,
-                        "adherence_counselling": NO,
+                        "adherence_counselling": NOT_APPLICABLE,
                     }
                 )
                 form_validator = self.validate_form_validator(cleaned_data)
                 self.assertDictEqual({}, form_validator._errors)
 
-    def test_adherence_counselling_invalid_if_deceased(self):
+    def test_adherence_counselling_na_if_deceased(self):
         cleaned_data = self.get_valid_patient_telephone_assessment_data()
         cleaned_data.update({"info_source": "next_of_kin", "survival_status": DEAD})
         form_validator = self.validate_form_validator(cleaned_data)
-        self.assertIn("adherence_counselling", form_validator._errors)
-        self.assertIn(
-            (
-                "Invalid: Adherence counselling not expected if "
-                "survival status is 'Deceased'"
-            ),
-            str(form_validator._errors.get("adherence_counselling")),
+        self.assertFieldFormValidationErrorRaised(
+            form_validator=form_validator,
+            field="adherence_counselling",
+            expected_msg="Invalid: Expected 'Not applicable' if survival status is 'Deceased'",
         )
-        self.assertEqual(len(form_validator._errors), 1, form_validator._errors)
+
+    def test_adherence_counselling_applicable_if_not_deceased(self):
+        survival_statuses = [ss[0] for ss in PATIENT_STATUSES if ss[0] != DEAD]
+        for survival_status in survival_statuses:
+            with self.subTest(survival_status=survival_status):
+                cleaned_data = deepcopy(
+                    self.get_valid_patient_telephone_assessment_data()
+                )
+                cleaned_data.update(
+                    {
+                        "info_source": "next_of_kin",
+                        "survival_status": survival_status,
+                        "adherence_counselling": NOT_APPLICABLE,
+                    }
+                )
+                form_validator = self.validate_form_validator(cleaned_data)
+                self.assertFieldFormValidationErrorRaised(
+                    form_validator=form_validator,
+                    field="adherence_counselling",
+                    expected_msg="This field is applicable.",
+                )

--- a/effect_subject/tests/tests/test_followup.py
+++ b/effect_subject/tests/tests/test_followup.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from django.test import TestCase, tag
+from django.test import TestCase
 from edc_constants.constants import DEAD, NO, NOT_APPLICABLE, OTHER, YES
 from model_bakery import baker
 
@@ -11,7 +11,6 @@ from effect_subject.forms import FollowupForm
 from effect_subject.forms.followup_form import FollowupFormValidator
 
 
-@tag("fu")
 class TestFollowup(EffectTestCaseMixin, TestCase):
     def setUp(self):
         super().setUp()
@@ -24,7 +23,6 @@ class TestFollowup(EffectTestCaseMixin, TestCase):
         form.is_valid()
 
 
-@tag("fu")
 class TestFollowupFormValidation(EffectTestCaseMixin, TestCase):
 
     form_validator_default_form_cls = FollowupFormValidator


### PR DESCRIPTION
Includes:
    - rename/standardise 'Clinical Assessment' to be 'Follow-up' throughout
    - add survival status help text, for 'Deceased' and 'Alive, but unwell' choices
    - modify adherence_counselling to only be applicable if not 'Deceased'